### PR TITLE
fix: incorrect upstream_response_time when nginx returns 499

### DIFF
--- a/src/ngx_http_lua_var_module.c
+++ b/src/ngx_http_lua_var_module.c
@@ -111,21 +111,18 @@ ngx_http_lua_var_ffi_upstream_response_time(ngx_http_request_t *r,
     state = r->upstream_states->elts;
 
     for ( ;; ) {
-        if (state[i].status) {
+        if (type == 1) {
+            ms = state[i].header_time;
 
-            if (type == 1 && state[i].header_time != (ngx_msec_t) -1) {
-                ms = state[i].header_time;
+        } else if (type == 2) {
+            ms = state[i].connect_time;
 
-            } else if (type == 2 && state[i].connect_time != (ngx_msec_t) -1) {
-                ms = state[i].connect_time;
-
-            } else {
-                ms = state[i].response_time;
-            }
-
-            ms = ngx_max(ms, 0);
-            total_ms = total_ms + ms;
+        } else {
+            ms = state[i].response_time;
         }
+
+        ms = ngx_max(ms, 0);
+        total_ms = total_ms + ms;
 
         if (++i == r->upstream_states->nelts) {
             break;

--- a/t/upstream_response_time_bugfix.t
+++ b/t/upstream_response_time_bugfix.t
@@ -1,0 +1,38 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua 'no_plan';
+
+repeat_each(1);
+
+#no_shuffle();
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: ignore the client abort event in the user callback
+--- config
+    location /t {
+        proxy_pass http://127.0.0.1:$server_port/delay;
+        log_by_lua_block {
+            local var = require("resty.ngxvar")
+            local req = var.request()
+            ngx.log(ngx.NOTICE, "validate upstream_response_time: ", tonumber(var.fetch("upstream_response_time", req)) > 0)
+        }
+    }
+    location = /delay {
+        content_by_lua_block {
+            ngx.sleep(2)
+        }
+    }
+--- request
+GET /t
+
+--- timeout: 0.2
+--- abort
+--- wait: 0.7
+--- ignore_response
+--- no_error_log
+[error]
+--- error_log
+validate upstream_response_time: true


### PR DESCRIPTION
upstream_response_time from lua-var-nginx-module is incorrect.
Because it checks the upstream response status first (the initial value is 0), it would get the response time only when the status is not 0. But in 499 case, the status is 0 because 499 is internal status code but not from upstream.

However, the nginx way is to get the response time ignoreless of the status code.
The solution should be to align with the nginx way.